### PR TITLE
feat: add subdomain variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -170,7 +170,7 @@ Type: `string`
 
 ==== [[input_base_domain]] <<input_base_domain,base_domain>>
 
-Description: The base domain used for Ingresses. If not provided, nip.io will be used taking the NLB IP address.
+Description: The base domain used for ingresses. If not provided, nip.io will be used taking the NLB IP address.
 
 Type: `string`
 
@@ -201,6 +201,14 @@ Type: `string`
 === Optional Inputs
 
 The following input variables are optional (have default values):
+
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: The subdomain used for ingresses.
+
+Type: `string`
+
+Default: `"apps"`
 
 ==== [[input_dns_zone_resource_group_name]] <<input_dns_zone_resource_group_name,dns_zone_resource_group_name>>
 
@@ -460,10 +468,16 @@ Description: Certificate Client Certificate required to communicate with the clu
 |yes
 
 |[[input_base_domain]] <<input_base_domain,base_domain>>
-|The base domain used for Ingresses. If not provided, nip.io will be used taking the NLB IP address.
+|The base domain used for ingresses. If not provided, nip.io will be used taking the NLB IP address.
 |`string`
 |n/a
 |yes
+
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|The subdomain used for ingresses.
+|`string`
+|`"apps"`
+|no
 
 |[[input_location]] <<input_location,location>>
 |The location where the Kubernetes cluster will be created along side with it's own resource group and associated resources.

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ data "azurerm_dns_zone" "this" {
 }
 
 resource "azurerm_dns_cname_record" "this" {
-  name                = format("*.apps.%s", var.cluster_name)
+  name                = format("*.%s", trimprefix("${var.subdomain}.${var.cluster_name}", "."))
   zone_name           = data.azurerm_dns_zone.this.name
   resource_group_name = var.dns_zone_resource_group_name
   ttl                 = 300

--- a/variables.tf
+++ b/variables.tf
@@ -8,8 +8,14 @@ variable "cluster_name" {
 }
 
 variable "base_domain" {
-  description = "The base domain used for Ingresses. If not provided, nip.io will be used taking the NLB IP address."
+  description = "The base domain used for ingresses. If not provided, nip.io will be used taking the NLB IP address."
   type        = string
+}
+
+variable "subdomain" {
+  description = "The subdomain used for ingresses."
+  type        = string
+  default     = "apps"
 }
 
 variable "location" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,7 @@ variable "subdomain" {
   description = "The subdomain used for ingresses."
   type        = string
   default     = "apps"
+  nullable    = false
 }
 
 variable "location" {


### PR DESCRIPTION
## Description of the changes

This PR adds a way to change the subdomain of the ingresses, even remove it if desired. It replicates the other PRs on the other modules.

## Breaking change

- [x] No
