### PR TITLE
feat: upgrade K8s version, increase default node size and add variable to specify RG of the virtual network

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -232,7 +232,7 @@ Description: The Kubernetes version to use on the control-plane.
 
 Type: `string`
 
-Default: `"1.28"`
+Default: `"1.29"`
 
 ==== [[input_automatic_channel_upgrade]] <<input_automatic_channel_upgrade,automatic_channel_upgrade>>
 
@@ -263,6 +263,14 @@ Default: `null`
 Description: Maintenance window configuration for this Kubernetes Cluster Nodes' OS Image. Only has an effect if the automatic upgrades are enabled using the variable `node_os_channel_upgrade`. Please check the variable of the same name https://github.com/Azure/terraform-azurerm-aks/blob/main/variables.tf[on the original module] for more information and to see the required values.
 
 Type: `any`
+
+Default: `null`
+
+==== [[input_virtual_network_resource_group_name]] <<input_virtual_network_resource_group_name,virtual_network_resource_group_name>>
+
+Description: The name of the resource group where the virtual network resides.
+
+Type: `string`
 
 Default: `null`
 
@@ -312,7 +320,7 @@ Description: The default virtual machine size for the Kubernetes agents. Changin
 
 Type: `string`
 
-Default: `"Standard_D2s_v3"`
+Default: `"Standard_D4s_v3"`
 
 ==== [[input_agents_count]] <<input_agents_count,agents_count>>
 
@@ -506,7 +514,7 @@ Description: Certificate Client Certificate required to communicate with the clu
 |[[input_kubernetes_version]] <<input_kubernetes_version,kubernetes_version>>
 |The Kubernetes version to use on the control-plane.
 |`string`
-|`"1.28"`
+|`"1.29"`
 |no
 
 |[[input_automatic_channel_upgrade]] <<input_automatic_channel_upgrade,automatic_channel_upgrade>>
@@ -538,6 +546,12 @@ Description: Certificate Client Certificate required to communicate with the clu
 |`string`
 |n/a
 |yes
+
+|[[input_virtual_network_resource_group_name]] <<input_virtual_network_resource_group_name,virtual_network_resource_group_name>>
+|The name of the resource group where the virtual network resides.
+|`string`
+|`null`
+|no
 
 |[[input_cluster_subnet]] <<input_cluster_subnet,cluster_subnet>>
 |The subnet CIDR where to deploy the cluster, included in the virtual network created.
@@ -578,7 +592,7 @@ Description: Certificate Client Certificate required to communicate with the clu
 |[[input_agents_size]] <<input_agents_size,agents_size>>
 |The default virtual machine size for the Kubernetes agents. Changing this without specifying `var.temporary_name_for_rotation` forces a new resource to be created.
 |`string`
-|`"Standard_D2s_v3"`
+|`"Standard_D4s_v3"`
 |no
 
 |[[input_agents_count]] <<input_agents_count,agents_count>>

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "azurerm_dns_cname_record" "this" {
 
 resource "azurerm_subnet" "this" {
   name                 = "${var.cluster_name}-snet"
-  resource_group_name  = var.resource_group_name
+  resource_group_name  = var.virtual_network_resource_group_name != null ? var.virtual_network_resource_group_name : var.resource_group_name
   address_prefixes     = [var.cluster_subnet]
   virtual_network_name = var.virtual_network_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -145,7 +145,7 @@ variable "agents_labels" {
 variable "agents_size" {
   description = "The default virtual machine size for the Kubernetes agents. Changing this without specifying `var.temporary_name_for_rotation` forces a new resource to be created. " # TODO Add link to documentation to get available sizes
   type        = string
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D4s_v3"
 }
 
 variable "agents_count" {

--- a/variables.tf
+++ b/variables.tf
@@ -95,6 +95,12 @@ variable "virtual_network_name" {
   type        = string
 }
 
+variable "virtual_network_resource_group_name" {
+  description = "The name of the resource group where the virtual network resides."
+  type        = string
+  default     = null
+}
+
 variable "cluster_subnet" {
   description = "The subnet CIDR where to deploy the cluster, included in the virtual network created."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "sku_tier" {
 variable "kubernetes_version" {
   description = "The Kubernetes version to use on the control-plane."
   type        = string
-  default     = "1.28"
+  default     = "1.29"
 }
 
 variable "automatic_channel_upgrade" {


### PR DESCRIPTION
## Description of the changes

This PR does the following:

- **feat: upgrade default Kubernetes version to v1.29**

- **fix: increase the size of the default nodes**
  I noticed that the DevOps Stack uses more resources that I expected at the beginning, so I'm increasing the default size of the nodes for the default node pool.

- **feat: add variable to set the resource group of the virtual network**
  This will allow us to have a virtual network in a different resource group than the clusters, although the ancient behavior will be preserved by default.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No
