### PR TITLE
Bump Azure/aks/azurerm Version from 7 to 9

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "this" {
 
 module "cluster" {
   source  = "Azure/aks/azurerm"
-  version = "~> 7.0"
+  version = "~> 9.0"
 
   cluster_name        = var.cluster_name
   prefix              = var.cluster_name

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "azurerm_resource_group" "this" {
 
 module "cluster" {
   source  = "Azure/aks/azurerm"
-  version = "~> 9.0"
+  version = "~> 10.0"
 
   cluster_name        = var.cluster_name
   prefix              = var.cluster_name

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,9 @@ module "cluster" {
   node_os_channel_upgrade    = var.node_os_channel_upgrade
   maintenance_window_node_os = var.maintenance_window_node_os
 
-  vnet_subnet                          = resource.azurerm_subnet.this.id
+  vnet_subnet = {
+    id = azurerm_subnet.this.id
+  }
   azure_policy_enabled                 = true
   cluster_log_analytics_workspace_name = var.cluster_name
   private_cluster_enabled              = false

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ module "cluster" {
   node_os_channel_upgrade    = var.node_os_channel_upgrade
   maintenance_window_node_os = var.maintenance_window_node_os
 
-  vnet_subnet_id                       = resource.azurerm_subnet.this.id
+  vnet_subnet                          = resource.azurerm_subnet.this.id
   azure_policy_enabled                 = true
   cluster_log_analytics_workspace_name = var.cluster_name
   private_cluster_enabled              = false

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ module "cluster" {
   node_os_channel_upgrade    = var.node_os_channel_upgrade
   maintenance_window_node_os = var.maintenance_window_node_os
 
+  vnet_subnet_id                       = resource.azurerm_subnet.this.id
   azure_policy_enabled                 = true
   cluster_log_analytics_workspace_name = var.cluster_name
   private_cluster_enabled              = false

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ resource "azurerm_resource_group" "this" {
 module "cluster" {
   source  = "Azure/aks/azurerm"
   version = "~> 10.0"
+  location = var.location
 
   cluster_name        = var.cluster_name
   prefix              = var.cluster_name
@@ -39,7 +40,6 @@ module "cluster" {
   node_os_channel_upgrade    = var.node_os_channel_upgrade
   maintenance_window_node_os = var.maintenance_window_node_os
 
-  vnet_subnet_id                       = resource.azurerm_subnet.this.id
   azure_policy_enabled                 = true
   cluster_log_analytics_workspace_name = var.cluster_name
   private_cluster_enabled              = false
@@ -50,7 +50,6 @@ module "cluster" {
   log_analytics_workspace_enabled    = false
   oidc_issuer_enabled                = true
   rbac_aad_admin_group_object_ids    = var.rbac_aad_admin_group_object_ids
-  rbac_aad_managed                   = true
   role_based_access_control_enabled  = true
   workload_identity_enabled          = true
 


### PR DESCRIPTION
## Description of the changes

As in [main.tf](https://github.com/Azure/terraform-azurerm-aks/blob/3178d8ce96e33ba1647efba900f174821e4145a1/main.tf#L563)

```terraform
resource "azapi_update_resource" "aks_cluster_post_create" {
  type = "Microsoft.ContainerService/managedClusters@2023-01-02-preview"
  body = jsonencode({
    properties = {
      kubernetesVersion = var.kubernetes_version
    }
  })
  resource_id = azurerm_kubernetes_cluster.main.id

  lifecycle {
    ignore_changes       = all
    replace_triggered_by = [null_resource.kubernetes_version_keeper.id]
  }
}
```

Version 2023-01-02-preview no longer exists for location 'francecentral' we need to bump to at least v9 that uses the correct api versions. [main.tf](https://github.com/Azure/terraform-azurerm-aks/blob/9e5c3a53ec63a9c581a714178afe4b7ed6872da7/main.tf#L638)

```
│ RESPONSE 400: 400 Bad Request
│ ERROR CODE: NoRegisteredProviderFound
│ --------------------------------------------------------------------------------
│ {
│   "error": {
│     "code": "NoRegisteredProviderFound",
│     "message": "No registered resource provider found for location 'francecentral' and API version '2023-01-02-preview' for type 'managedClusters'. The supported api-versions are '2017-08-31, 2018-03-31, 2019-02-01, 2019-04-01, 2019-06-01, 2019-08-01, 2019-10-01, 2019-11-01, 2020-01-01, 2020-02-01, 2020-03-01, 2020-04-01, 2020-06-01, 2020-07-01, 2020-09-01, 2020-11-01, 2020-12-01, 2021-02-01, 2021-03-01, 2021-05-01, 2021-07-01, 2021-08-01, 2021-09-01, 2021-10-01, 2022-01-01, 2022-02-01, 2022-03-01, 2022-04-01, 2022-06-01, 2022-07-01, 2022-08-01, 2022-09-01, 2022-11-01, 2023-01-01, 2023-02-01, 2023-03-01, 2023-04-01, 2023-05-01, 2023-06-01, 2023-07-01, 2023-08-01, 2023-09-01, 2023-09-02-preview, 2023-10-01, 2023-10-02-preview, 2023-11-01, 2023-11-02-preview, 2024-01-01, 2024-01-02-preview, 2024-02-01, 2024-02-02-preview, 2024-03-02-preview, 2024-04-02-preview, 2024-05-01, 2024-05-02-preview, 2024-06-01, 2024-06-02-preview, 2024-07-01, 2024-07-02-preview, 2024-08-01, 2024-08-02-preview, 2024-09-01, 2024-09-02-preview, 2024-10-01, 2024-10-02-preview, 2025-01-01, 2025-01-02-preview, 2025-02-01, 2025-02-02-preview, 2025-03-01, 2025-03-02-preview, 2025-04-01, 2025-04-02-preview, 2025-05-01, 2025-05-02-preview'. The supported locations are 'australiacentral, australiacentral2, australiaeast, australiasoutheast, brazilsouth, brazilsoutheast, canadacentral, canadaeast, centralindia, centralus, chilecentral, eastasia, eastus, eastus2, francecentral, francesouth, germanynorth, germanywestcentral, indonesiacentral, israelcentral, italynorth, japaneast, japanwest, jioindiacentral, jioindiawest, koreacentral, koreasouth, malaysiawest, mexicocentral, newzealandnorth, northcentralus, northeurope, norwayeast, norwaywest, polandcentral, qatarcentral, southafricanorth, southafricawest, southcentralus, southindia, southeastasia, spaincentral, swedencentral, switzerlandnorth, switzerlandwest, uaecentral, uaenorth, uksouth, ukwest, westcentralus, westeurope, westus, westus2, westus3'."
│   }
│ }
│ --------------------------------------------------------------------------------
```


## Breaking change

- [ ] No
- [ ] Yes
